### PR TITLE
Fix typo in Gyeyu header

### DIFF
--- a/src/components/Method/Method.js
+++ b/src/components/Method/Method.js
@@ -5,7 +5,7 @@ export default function Method() {
   return (
     <section id="method">
       <GridContainer>
-        <h1 className="text-4xl">Gyeyu Revolte of 1453</h1>
+        <h1 className="text-4xl">Gyeyu Revolt of 1453</h1>
         <GridHighlight>
           <Gyeyu />
         </GridHighlight>


### PR DESCRIPTION
## Summary
- fix spelling of "Gyeyu Revolt" in method header

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: private package requires login)*

------
https://chatgpt.com/codex/tasks/task_e_6840767ae8cc832d94924ed22f8f552a