### PR TITLE
Fix Data statistics animation IDs

### DIFF
--- a/src/components/Data/Age.js
+++ b/src/components/Data/Age.js
@@ -25,7 +25,11 @@ export default function Age() {
   useEffect(() => {
     const svg = d3.select(ref.current);
     AgeLine(svg, status);
-  });
+    return () => {
+      d3.selectAll(".statusOption").on("mouseover", null);
+      svg.selectAll("*").remove();
+    };
+  }, []);
 
   return (
     <section id="age">

--- a/src/components/Data/AgeLine.js
+++ b/src/components/Data/AgeLine.js
@@ -87,6 +87,7 @@ export default function AgeLine(svg, status) {
     .attr("fill", "#b4c5d9");
 
   function updateChart(selectedStatus) {
+    d3.selectAll(".allpath").remove();
     let density;
     if (selectedStatus === "all") {
       const allColors = ["#b4c5d9", "#c5d9b4", "#d9b5b4"];
@@ -152,8 +153,6 @@ export default function AgeLine(svg, status) {
       }
     } else {
       // Add the average line
-
-      d3.selectAll(".allpath").remove();
       density = kde(
         Lifespan.filter((d) => d.status === selectedStatus).map(
           (d) => +d["lifespan"]

--- a/src/components/Data/Data.js
+++ b/src/components/Data/Data.js
@@ -35,7 +35,9 @@ export default function Data() {
           ease: "power1.inOut",
         })
         .from("#number2", { innerText: 0, snap: { innerText: 1 } })
-        .from("#number3", { innerText: 0, snap: { innerText: 1 } });
+        .from("#number3", { innerText: 0, snap: { innerText: 1 } })
+        .from("#number4", { innerText: 0, snap: { innerText: 1 } })
+        .from("#number5", { innerText: 0, snap: { innerText: 1 } });
     }, dataRef.current);
     return () => ctx.revert();
   }, []);
@@ -104,13 +106,13 @@ export default function Data() {
           <Grid item xs={3} />
           <Grid item xs={6}>
             <div className="flex justify-between flex-wrap my-20">
-              {[
-                { id: "number1", value: 26, label: "Monarchs" },
-                { id: "number1", value: 214, label: "Topics" },
-                { id: "number2", value: 60158, label: "People appeared" },
-                { id: "number2", value: 183342, label: "Days (1392-1894)" },
-                { id: "number3", value: 384279, label: "Articles" },
-              ].map(({ id, value, label }) => (
+                {[
+                  { id: "number1", value: 26, label: "Monarchs" },
+                  { id: "number2", value: 214, label: "Topics" },
+                  { id: "number3", value: 60158, label: "People appeared" },
+                  { id: "number4", value: 183342, label: "Days (1392-1894)" },
+                  { id: "number5", value: 384279, label: "Articles" },
+                ].map(({ id, value, label }) => (
                 <p key={label}>
                   <span className="number" id={id}>
                     {value}

--- a/src/components/Data/Data.js
+++ b/src/components/Data/Data.js
@@ -29,13 +29,13 @@ export default function Data() {
       ntl
         .from("#number1", {
           innerText: 0,
-          snap: {
-            innerText: 1,
-          },
+          snap: { innerText: 1 },
           ease: "power1.inOut",
         })
         .from("#number2", { innerText: 0, snap: { innerText: 1 } })
-        .from("#number3", { innerText: 0, snap: { innerText: 1 } });
+        .from("#number3", { innerText: 0, snap: { innerText: 1 } })
+        .from("#number4", { innerText: 0, snap: { innerText: 1 } })
+        .from("#number5", { innerText: 0, snap: { innerText: 1 } });
     }, dataRef.current);
     return () => ctx.revert();
   }, []);
@@ -106,10 +106,10 @@ export default function Data() {
             <div className="flex justify-between flex-wrap my-20">
               {[
                 { id: "number1", value: 26, label: "Monarchs" },
-                { id: "number1", value: 214, label: "Topics" },
-                { id: "number2", value: 60158, label: "People appeared" },
-                { id: "number2", value: 183342, label: "Days (1392-1894)" },
-                { id: "number3", value: 384279, label: "Articles" },
+                { id: "number2", value: 214, label: "Topics" },
+                { id: "number3", value: 60158, label: "People appeared" },
+                { id: "number4", value: 183342, label: "Days (1392-1894)" },
+                { id: "number5", value: 384279, label: "Articles" },
               ].map(({ id, value, label }) => (
                 <p key={label}>
                   <span className="number" id={id}>

--- a/src/components/Method/Method.js
+++ b/src/components/Method/Method.js
@@ -5,7 +5,7 @@ export default function Method() {
   return (
     <section id="method">
       <GridContainer>
-        <h1 className="text-4xl">Gyeyu Revolte of 1453</h1>
+        <h1 className="text-4xl">Gyeyu Revolt of 1453</h1>
         <GridHighlight>
           <Gyeyu />
         </GridHighlight>


### PR DESCRIPTION
## Summary
- use unique IDs for each statistic in Data component
- update GSAP timeline to animate number1 through number5

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684076859a5c832d8c897fd06750590e