### PR TITLE
Improve animations and add lifespan bar chart

### DIFF
--- a/src/components/Data/Age.js
+++ b/src/components/Data/Age.js
@@ -24,8 +24,14 @@ export default function Age() {
 
   useEffect(() => {
     const svg = d3.select(ref.current);
+    svg.selectAll('*').remove();
     AgeLine(svg, status);
-  });
+
+    return () => {
+      svg.selectAll('*').remove();
+      d3.selectAll('.statusOption').on('mouseover', null);
+    };
+  }, []);
 
   return (
     <section id="age">

--- a/src/components/Data/AgeLine.js
+++ b/src/components/Data/AgeLine.js
@@ -105,7 +105,6 @@ export default function AgeLine(svg, status) {
             .append("path")
             .attr("class", "allpath")
             .datum(density)
-            .attr("autoalpha", ".8")
             .attr("opacity", ".8")
             .attr("stroke", "#000")
             .attr("stroke-width", 1)

--- a/src/components/Data/AverageLifespanBar.js
+++ b/src/components/Data/AverageLifespanBar.js
@@ -1,0 +1,71 @@
+import React, { useRef, useEffect } from "react";
+import * as d3 from "d3";
+import Lifespan from "./lifespan.json";
+
+export default function AverageLifespanBar() {
+  const ref = useRef();
+
+  useEffect(() => {
+    const svg = d3.select(ref.current);
+    const width = 400;
+    const height = 300;
+    const margin = { top: 20, right: 20, bottom: 40, left: 40 };
+    svg.attr("viewBox", [0, 0, width, height]);
+
+    const data = d3.rollups(
+      Lifespan,
+      (v) => d3.mean(v, (d) => +d.lifespan),
+      (d) => d.status
+    );
+
+    const x = d3
+      .scaleBand()
+      .domain(data.map((d) => d[0]))
+      .range([margin.left, width - margin.right])
+      .padding(0.1);
+
+    const y = d3
+      .scaleLinear()
+      .domain([0, d3.max(data, (d) => d[1])])
+      .nice()
+      .range([height - margin.bottom, margin.top]);
+
+    svg
+      .append("g")
+      .attr("transform", `translate(0,${height - margin.bottom})`)
+      .call(d3.axisBottom(x))
+      .selectAll("text")
+      .style("font-family", "IM Fell English");
+
+    svg
+      .append("g")
+      .attr("transform", `translate(${margin.left},0)`)
+      .call(d3.axisLeft(y))
+      .selectAll("text")
+      .style("font-family", "IM Fell English");
+
+    svg
+      .selectAll("rect")
+      .data(data)
+      .join("rect")
+      .attr("x", (d) => x(d[0]))
+      .attr("y", (d) => y(d[1]))
+      .attr("width", x.bandwidth())
+      .attr("height", (d) => y(0) - y(d[1]))
+      .attr("fill", "#6b7280");
+
+    svg
+      .selectAll("text.bar")
+      .data(data)
+      .join("text")
+      .attr("class", "bar")
+      .attr("text-anchor", "middle")
+      .attr("x", (d) => x(d[0]) + x.bandwidth() / 2)
+      .attr("y", (d) => y(d[1]) - 5)
+      .text((d) => d[1].toFixed(1))
+      .style("font-size", "12px")
+      .style("font-family", "IM Fell English");
+  }, []);
+
+  return <svg ref={ref} style={{ width: "100%", height: 300 }} />;
+}

--- a/src/components/Data/Data.js
+++ b/src/components/Data/Data.js
@@ -4,6 +4,7 @@ import { GridNormal, GridHighlight, GridContainer } from "../Layout";
 
 import Cartogram from "./Cartogram";
 import Age from "./Age";
+import AverageLifespanBar from "./AverageLifespanBar";
 import Grid from "@mui/material/Grid";
 
 import { useRef, useLayoutEffect } from "react";
@@ -27,15 +28,15 @@ export default function Data() {
         },
       });
       ntl
-        .from("#number1", {
+        .from("#numMonarchs", {
           innerText: 0,
-          snap: {
-            innerText: 1,
-          },
+          snap: { innerText: 1 },
           ease: "power1.inOut",
         })
-        .from("#number2", { innerText: 0, snap: { innerText: 1 } })
-        .from("#number3", { innerText: 0, snap: { innerText: 1 } });
+        .from("#numTopics", { innerText: 0, snap: { innerText: 1 } })
+        .from("#numPeople", { innerText: 0, snap: { innerText: 1 } })
+        .from("#numDays", { innerText: 0, snap: { innerText: 1 } })
+        .from("#numArticles", { innerText: 0, snap: { innerText: 1 } });
     }, dataRef.current);
     return () => ctx.revert();
   }, []);
@@ -69,6 +70,7 @@ export default function Data() {
           <Grid item xs={3} />
           <Grid item xs={6}>
             <Age />
+            <AverageLifespanBar />
           </Grid>
           <Grid item xs={3} />
         </Grid>
@@ -105,11 +107,11 @@ export default function Data() {
           <Grid item xs={6}>
             <div className="flex justify-between flex-wrap my-20">
               {[
-                { id: "number1", value: 26, label: "Monarchs" },
-                { id: "number1", value: 214, label: "Topics" },
-                { id: "number2", value: 60158, label: "People appeared" },
-                { id: "number2", value: 183342, label: "Days (1392-1894)" },
-                { id: "number3", value: 384279, label: "Articles" },
+                { id: "numMonarchs", value: 26, label: "Monarchs" },
+                { id: "numTopics", value: 214, label: "Topics" },
+                { id: "numPeople", value: 60158, label: "People appeared" },
+                { id: "numDays", value: 183342, label: "Days (1392-1894)" },
+                { id: "numArticles", value: 384279, label: "Articles" },
               ].map(({ id, value, label }) => (
                 <p key={label}>
                   <span className="number" id={id}>


### PR DESCRIPTION
## Summary
- clean up Age chart rendering and remove stray event listeners
- fix lifetime density chart attr issue
- animate data numbers with unique IDs
- add AverageLifespanBar visualization showing mean lifespan per status

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840770a7c50832daa73b13d97c90355